### PR TITLE
Add the option to use html for all of the header linked pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,14 +163,19 @@ This section controls aspects of how the system works.
 
 The ```exportPathLocation``` is required and determines where exported data files are saved when the database is exported.
 
-Three required boolean values determine which links appear in the header of the webpage. If any of these booleans are set to true the corresponding link key is required and this should point to a [published google document](https://support.google.com/docs/answer/183965?hl=en&co=GENIE.Platform%3DDesktop). The keys and their corresponding links are listed below.
+Three required boolean values determine which links appear in the header of the webpage. If any of these booleans are set to true either the corresponding link key or the corresponding html key is required. If using the link key this should point to a [published google document](https://support.google.com/docs/answer/183965?hl=en&co=GENIE.Platform%3DDesktop). If using the html key then the HTML fragment should be wrapped in a ```<div>``` and contain the HTML you want to be displayed in the template. The template will take care of the header itself.
+
+The keys and their corresponding link/html keys are listed below.
 
 * renderUserInstructionPage
   * userInstructionLink
+  * userInstructionHtml
 * renderEthicsAgreementPage
   * userEthicsAgreementLink
+  * userEthicsAgreementHtml
 * renderSitePoliciesPage
   * sitePoliciesLink
+  * sitePoliciesHtml
 
 There is also a required boolean key ```renderCookiesFooter```, which determines whether the user is asked to accept the website cookies when first opening the website. The text for the cookie footer is stored in the language file but it you want to customise if for a particular project then the ```siteCookiesText``` key can be added to the project configuration with the string you want to display.
 

--- a/comparison_interface/configuration/schema.py
+++ b/comparison_interface/configuration/schema.py
@@ -286,17 +286,29 @@ class BehaviourConfiguration(Schema):
     cycleLength = fields.Integer(required=False)
     maximumCyclesPerUser = fields.Integer(required=False)
     userInstructionLink = fields.URL(required=False, validate=[validate.Length(min=1)])
+    userInstructionHtml = fields.Str(required=False, validate=[validate.Length(min=1, max=100)])
     userEthicsAgreementLink = fields.URL(required=False, validate=[validate.Length(min=1)])
+    userEthicsAgreementHtml = fields.Str(required=False, validate=[validate.Length(min=1, max=100)])
     sitePoliciesLink = fields.URL(required=False, validate=[validate.Length(min=1)])
     sitePoliciesHtml = fields.Str(required=False, validate=[validate.Length(min=1, max=100)])
 
     @post_load
     def _post_load_validation(self, data, **kwargs):
-        if data['renderEthicsAgreementPage'] and 'userEthicsAgreementLink' not in data:
-            raise ValidationError("Field userEthicsAgreementLink is required if renderEthicsAgreementPage is true")
+        if data['renderEthicsAgreementPage'] and (
+            'userEthicsAgreementLink' not in data and 'userEthicsAgreementHtml' not in data
+        ):
+            raise ValidationError(
+                "Either the userEthicsAgreementLink or the userEthicsAgreementHtml field is required if "
+                "renderEthicsAgreementPage is true"
+            )
 
-        if data['renderUserInstructionPage'] and 'userInstructionLink' not in data:
-            raise ValidationError("Field userInstructionLink is required if renderUserInstructionPage is true")
+        if data['renderUserInstructionPage'] and (
+            'userInstructionLink' not in data and 'userInstructionHtml' not in data
+        ):
+            raise ValidationError(
+                "Either the userInstructionLink or the userInstructionHtml field is required if "
+                "renderUserInstructionPage is true"
+            )
 
         if data['renderSitePoliciesPage'] and ('sitePoliciesLink' not in data and 'sitePoliciesHtml' not in data):
             raise ValidationError(

--- a/comparison_interface/configuration/website.py
+++ b/comparison_interface/configuration/website.py
@@ -26,7 +26,9 @@ class Settings:
     BEHAVIOUR_CYCLE_LENGTH = "cycleLength"
     BEHAVIOUR_MAX_CYCLES = "maximumCyclesPerUser"
     BEHAVIOUR_USER_INSTRUCTION_LINK = "userInstructionLink"
+    BEHAVIOUR_USER_INSTRUCTION_HTML = "userInstructionHtml"
     BEHAVIOUR_ETHICS_AGREEMENT_LINK = "userEthicsAgreementLink"
+    BEHAVIOUR_ETHICS_AGREEMENT_HTML = "userEthicsAgreementHtml"
     BEHAVIOUR_SITE_POLICIES_LINK = "sitePoliciesLink"
     BEHAVIOUR_SITE_POLICIES_HTML = "sitePoliciesHtml"
     # Group related configuration keys

--- a/comparison_interface/templates/pages/ethics.html
+++ b/comparison_interface/templates/pages/ethics.html
@@ -2,9 +2,15 @@
 {% block title %}: {{ethics_agreement_page_title}}{% endblock %}
 {% block content %}
 <div>
-    <div class="full-height-iframe">
-        <iframe title="Ethics agreement" style="height:100%;width:100%;" scrolling="yes" class="embed-responsive" src="{{ethics_agreement_link}}"></iframe>
-    </div>
+    {% if google_doc %}
+        <div class="full-height-iframe">
+            <iframe title="Ethics agreement" style="height:100%;width:100%;" scrolling="yes" class="embed-responsive" src="{{ethics_agreement_link}}"></iframe>
+        </div>
+    {% else %}
+        <div class="inner-page">
+            {{ html_string|safe }}
+        </div>
+    {% endif %}
     <div class="text-center">
         <a class="btn btn-primary" href="{{ url_for('.user_registration') }}">{{ethics_agreement_back_button}}</a>
     </div>

--- a/comparison_interface/templates/pages/introduction.html
+++ b/comparison_interface/templates/pages/introduction.html
@@ -2,9 +2,15 @@
 {% block title %}: {{introduction_page_title}}{% endblock %}
 {% block content %}
 <div>
-    <div class="full-height-iframe">
-        <iframe title="Introduction" style="height:100%;width:100%;" scrolling="yes" class="embed-responsive" src="{{user_instruction_link}}"></iframe>
-    </div>
+    {% if google_doc %}
+        <div class="full-height-iframe">
+            <iframe title="Introduction" style="height:100%;width:100%;" scrolling="yes" class="embed-responsive" src="{{user_instruction_link}}"></iframe>
+        </div>
+    {% else %}
+        <div class="inner-page">
+            {{ html_string|safe }}
+        </div>
+    {% endif %}
     <div class="text-center">
         <a class="btn btn-primary" href="{{ url_for('.user_registration') }}">{{introduction_continue_button}}</a>
     </div>

--- a/comparison_interface/views/ethics.py
+++ b/comparison_interface/views/ethics.py
@@ -1,3 +1,5 @@
+import os
+
 from ..configuration.website import Settings as WS
 from .request import Request
 
@@ -5,15 +7,30 @@ from .request import Request
 class Ethics(Request):
     """Render the ethics agreement page.
 
-    This page containing an iframe with a link to a google doc with the ethics agreement.
+    This page either contains an iframe with a link to a google doc or the html from the location specified.
     """
 
     def get(self, _):
         """Request get handler."""
+        if WS.configuration_has_key(WS.BEHAVIOUR_ETHICS_AGREEMENT_LINK, self._app):
+            return self._render_template(
+                'pages/ethics.html',
+                {
+                    'google_doc': True,
+                    'ethics_agreement_link': WS.get_behaviour_conf(WS.BEHAVIOUR_ETHICS_AGREEMENT_LINK, self._app),
+                    'ethics_agreement_back_button': WS.get_text(WS.ETHICS_AGREEMENT_BACK_BUTTON_LABEL, self._app),
+                },
+            )
+        # otherwise we are have html to inject instead
+        ethics_agreement_html = WS.get_behaviour_conf(WS.BEHAVIOUR_ETHICS_AGREEMENT_HTML, self._app)
+        with open(os.path.join(self._app.root_path, ethics_agreement_html)) as input_file:
+            html_fragment = input_file.read()
+
         return self._render_template(
             'pages/ethics.html',
             {
-                'ethics_agreement_link': WS.get_behaviour_conf(WS.BEHAVIOUR_ETHICS_AGREEMENT_LINK, self._app),
+                'google_doc': False,
+                'html_string': html_fragment,
                 'ethics_agreement_back_button': WS.get_text(WS.ETHICS_AGREEMENT_BACK_BUTTON_LABEL, self._app),
             },
         )

--- a/comparison_interface/views/introduction.py
+++ b/comparison_interface/views/introduction.py
@@ -1,3 +1,5 @@
+import os
+
 from ..configuration.website import Settings as WS
 from .request import Request
 
@@ -5,15 +7,30 @@ from .request import Request
 class Introduction(Request):
     """Render the introduction page.
 
-    This page contains an iframe with a link to a google doc with text introducing the project.
+    This page either contains an iframe with a link to a google doc or the html from the location specified.
     """
 
     def get(self, _):
         """Request get handler."""
+        if WS.configuration_has_key(WS.BEHAVIOUR_USER_INSTRUCTION_LINK, self._app):
+            return self._render_template(
+                'pages/introduction.html',
+                {
+                    'google_doc': True,
+                    'user_instruction_link': WS.get_behaviour_conf(WS.BEHAVIOUR_USER_INSTRUCTION_LINK, self._app),
+                    'introduction_continue_button': WS.get_text(WS.INTRODUCTION_CONTINUE_BUTTON_LABEL, self._app),
+                },
+            )
+        # otherwise we are have html to inject instead
+        user_instruction_html = WS.get_behaviour_conf(WS.BEHAVIOUR_USER_INSTRUCTION_HTML, self._app)
+        with open(os.path.join(self._app.root_path, user_instruction_html)) as input_file:
+            html_fragment = input_file.read()
+
         return self._render_template(
             'pages/introduction.html',
             {
-                'user_instruction_link': WS.get_behaviour_conf(WS.BEHAVIOUR_USER_INSTRUCTION_LINK, self._app),
+                'google_doc': False,
+                'html_string': html_fragment,
                 'introduction_continue_button': WS.get_text(WS.INTRODUCTION_CONTINUE_BUTTON_LABEL, self._app),
             },
         )

--- a/comparison_interface/views/policies.py
+++ b/comparison_interface/views/policies.py
@@ -7,7 +7,7 @@ from .request import Request
 class Policies(Request):
     """Render the policies page.
 
-    This page contains an iframe with a link to a google doc containing the site policies.
+    This page either contains an iframe with a link to a google doc or the html from the location specified.
     """
 
     def get(self, _):
@@ -22,8 +22,8 @@ class Policies(Request):
                 },
             )
         # otherwise we are have html to inject instead
-        site_policies_link = WS.get_behaviour_conf(WS.BEHAVIOUR_SITE_POLICIES_HTML, self._app)
-        with open(os.path.join(self._app.root_path, site_policies_link)) as input_file:
+        site_policies_html = WS.get_behaviour_conf(WS.BEHAVIOUR_SITE_POLICIES_HTML, self._app)
+        with open(os.path.join(self._app.root_path, site_policies_html)) as input_file:
             html_fragment = input_file.read()
 
         return self._render_template(


### PR DESCRIPTION
Extend the option already used for site policies to the other pages linked from the header. 