### PR TITLE
add example of csv and update docs

### DIFF
--- a/comparison_interface/examples/csv_example/config-equal-item-weights.json
+++ b/comparison_interface/examples/csv_example/config-equal-item-weights.json
@@ -1,0 +1,66 @@
+{
+    "behaviourConfiguration": {
+        "exportPathLocation": "../exports",
+        "renderUserItemPreferencePage": false,
+        "offerEscapeRouteBetweenCycles": true,
+        "cycleLength": 10,
+        "maximumCyclesPerUser": 3,
+        "allowTies": true,
+        "allowSkip": true,
+        "allowBack": true,
+        "renderUserInstructionPage":  true,
+        "userInstructionLink": "https://docs.google.com/document/d/e/2PACX-1vT2yGXStletU0XGL6DaA45tSr3skJLIi2u-m5T9t3gNEjjXdN__c4yJhhN0CyzuDsFltKUFfBDt2qEJ/pub?embedded=true",
+        "renderEthicsAgreementPage":  true,
+        "userEthicsAgreementLink": "https://docs.google.com/document/d/e/2PACX-1vT2yGXStletU0XGL6DaA45tSr3skJLIi2u-m5T9t3gNEjjXdN__c4yJhhN0CyzuDsFltKUFfBDt2qEJ/pub?embedded=true",
+        "renderSitePoliciesPage":  true,
+        "sitePoliciesLink": "https://docs.google.com/document/d/e/2PACX-1vT2yGXStletU0XGL6DaA45tSr3skJLIi2u-m5T9t3gNEjjXdN__c4yJhhN0CyzuDsFltKUFfBDt2qEJ/pub?embedded=true",
+        "renderCookieBanner":  true    
+    },
+    "userFieldsConfiguration": [
+        {
+            "name": "name",
+            "displayName": "First Name",
+            "type": "text",
+            "maxLimit": 250,
+            "required": true
+        },
+        {
+            "name": "country",
+            "displayName": "In which country do you live?",
+            "type": "radio",
+            "option": ["England", "Northern Ireland", "Scotland", "Wales", "Outside the UK"],
+            "required": true
+        },
+        {
+            "name": "allergies",
+            "displayName": "Allergies",
+            "type": "dropdown",
+            "option": ["Yes", "No"],
+            "required": true
+        },
+        {
+            "name": "age",
+            "displayName": "Age in years",
+            "type": "int",
+            "maxLimit": 250,
+            "minLimit": 10,
+            "required": true
+        },
+        {
+            "name": "email",
+            "displayName": "Email",
+            "type": "email",
+            "maxLimit": 250,
+            "required": false
+        }
+    ],
+    "websiteTextConfiguration":  {
+        "userRegistrationGroupQuestionLabel": "Which of these regions are you familiar with?",
+        "userRegistrationGroupSelectionErr": "Please select at least one region.",
+        "rankItemInstructionLabel": "Click the region that has the higher rate of deprivation, then click on the blue confirm button.",
+        "additionalRegistrationPageText": ["The boundary outlines used in the images on this website are taken from the Office for National Statistics licensed under the Open Government Licence v.3.0 and Contains OS data © Crown copyright and database right 2024"]
+    },
+    "comparisonConfiguration" : {
+        "csvFile": "example.csv"
+    }
+}

--- a/comparison_interface/examples/csv_example/example.csv
+++ b/comparison_interface/examples/csv_example/example.csv
@@ -1,0 +1,13 @@
+Group Display Name,Group Name,Item Display Name,Item Name,Image
+England,england,North East,north_east,item_1.png
+England,england,North West,north_west,item_2.png
+England,england,Yorkshire & Humberside,yorkshire_and_humberside,item_3.png
+England,england,East Midlands,east_midlands,item_4.png
+England,england,West Midlands,west_midlands,item_5.png
+England,england,Eastern,eastern,item_6.png
+England,england,London,london,item_7.png
+England,england,South East,south_east,item_8.png
+England,england,South West,south_west,item_9.png
+"Wales, Scotland, Northern Ireland",wales_scotland_northern_ireland,Wales,wales,item_10.png
+"Wales, Scotland, Northern Ireland",wales_scotland_northern_ireland,Scotland,scotland,item_11.png
+"Wales, Scotland, Northern Ireland",wales_scotland_northern_ireland,Northern Ireland,northern_ireland,item_12.png

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -162,7 +162,7 @@ Refer to `examples/config-equal-item-weights.json` or `examples/config-equal-ite
 
 Refer to `examples/config-custom-item-weights.json` to configure a scenario where custom weights will be defined for all item pairs.
 
-If the configuration is being provided in a csv file, then the JSON file must provide the name of the csv file as follows:
+If the image configuration is being provided in a csv file, then the JSON file must provide the name of the csv file as follows:
 
 ```json
 "comparisonConfiguration" : {
@@ -177,6 +177,8 @@ The csv file must contain a minimum of two columns and up to five columns. The c
 + **item name** - *optional* - A string which identifies the image and only contains lowercase alpha numeric characters, underscores and dashes. This will be generated from the item display name if the column is not provided, but if there are any characters (with the exception of spaces) in the item display name column then validation errors will be raised.
 + **group display name** - *optional* - A string that identifies the group that this image belongs to. If this column is not provided then all of the images will be added to the single default group.
 + **group name** - *optional* - As with the item name this will be automatically generated from the group display name if that column is provided but if validation errors are raised due to special characters then this column may also be required.
+
+An example of a configuration using a csv file can be found in ```examples/csv_example```.
 
 ## Troubleshooting
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -42,6 +42,10 @@ This sequence of commands will allow you to setup and run one of the pre-configu
     + config-equal-item-weights-preference.json
 1. config-custom-item-weights.json
 
+In addition to the full JSON configurations listed above there is an example of a configuration of the first of them
+with the images configured with a csv file. This configuration can be found in the ```examples/csv_example``` directory.
+
+
 ### Initial setup
 
 If you are not using the dev container provided then:
@@ -51,7 +55,8 @@ If you are not using the dev container provided then:
 
 When running in production the secret key in the flask.py should also be changed.
 
-Open a terminal and run these commands replacing ```[configuration_file_name]``` with the name of the configuration file you want to try.
+Open a terminal and run these commands replacing ```[configuration_file_name]``` with the name of the configuration file you want to try. To try
+the csv file options replace with the the directory containing the JSON file and CSV file (```examples/csv_example```).
 
 ```bash
 flask --debug setup examples/[configuration_file_name]


### PR DESCRIPTION
Just adds an example of a config using a csv file for the images. Also updates docs which is worth a look to make sure they still make sense.