### PR TITLE
add a base config for testing and use it for tests

### DIFF
--- a/comparison_interface/__init__.py
+++ b/comparison_interface/__init__.py
@@ -10,6 +10,7 @@ from whitenoise import WhiteNoise
 
 from comparison_interface.cli import blueprint as commands_bp
 from comparison_interface.configuration.flask import Settings as FlaskSettings
+from comparison_interface.configuration.flask_testing import TestSettings
 from comparison_interface.configuration.website import Settings as WS
 from comparison_interface.db.connection import db
 from comparison_interface.db.models import WebsiteControl
@@ -17,7 +18,7 @@ from comparison_interface.main import blueprint as main_bp
 from comparison_interface.main.views.request import Request
 
 
-def create_app(test_config=None):
+def create_app(testing=False, test_config=None):
     """Start Flask website application.
 
     Args:
@@ -25,10 +26,17 @@ def create_app(test_config=None):
     """
     # Create and configure the app
     app = Flask(__name__, instance_relative_config=True, static_folder="static")
-    app.config.from_object(FlaskSettings)
 
+    # if we are testing then start with the base test config otherwise the main ones
+    if testing:
+        app.config.from_object(TestSettings)
+    else:
+        app.config.from_object(FlaskSettings)
+    # override the base settings with some extras passed in
     if test_config is not None:
         app.config.from_mapping(test_config)
+
+    # make sure the language setting is consistent
     try:
         language = app.config["LANGUAGE"].split(':')[1]
     except IndexError:

--- a/comparison_interface/configuration/flask_testing.py
+++ b/comparison_interface/configuration/flask_testing.py
@@ -1,0 +1,28 @@
+class TestSettings(object):
+    """Base Flask configuration for testing - some settings might be overridden in the tests themselves."""
+
+    TESTING = True
+    SECRET_KEY = 'ydf7ash*sdFdy'
+    SQLALCHEMY_DATABASE_URI = 'sqlite:///test_admin_database.db'
+    SQLALCHEMY_BINDS = {
+        'study_db': 'sqlite:///test_database.db',
+    }
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    SESSION_MINUTES_VALIDITY = 240  # Session expires after 4 hours of inactivity
+    SESSION_COOKIE_SECURE = False
+    SESSION_COOKIE_HTTPONLY = False
+    SESSION_COOKIE_SAMESITE = 'strict'
+    MAX_CONTENT_LENGTH = 4 * 1024 * 1024
+    LANGUAGE = 'en'
+    API_ACCESS = False
+    ADMIN_ACCESS = False
+    IMAGE_UPLOAD_DIR = 'temp_testing/static/images/'
+    HTML_PAGES_DIR = 'temp_testing/pages_html'
+    CONFIG_UPLOAD_DIR = 'temp_testing/project_configuration'
+    SECURITY_PASSWORD_SALT = 'hdys^d54$djf8fkas*'
+    SECURITY_URL_PREFIX = '/admin'
+    SECURITY_LOGIN_USER_TEMPLATE = 'user_login.html'
+    SECURITY_TWO_FACTOR = False
+    SECURITY_TWO_FACTOR_REQUIRED = False
+    SECURITY_POST_LOGIN_VIEW = '/admin/dashboard'
+    SECURITY_POST_LOGOUT_VIEW = '/admin/logged-out'

--- a/tests_python/conftest.py
+++ b/tests_python/conftest.py
@@ -14,15 +14,7 @@ from comparison_interface.db.setup import Setup as DBSetup
 
 
 def execute_setup(conf_file):
-    app = create_app(
-        {
-            "TESTING": True,
-            "API_ACCESS": False,
-            "LANGUAGE": "en",
-            "SQLALCHEMY_DATABASE_URI": "sqlite:///test_admin_database.db",
-            "SQLALCHEMY_BINDS": {"study_db": "sqlite:///test_database.db"},
-        }
-    )
+    app = create_app(testing=True)
     # 1. Validate the website configuration
     app.logger.info("Setting website configuration")
     WS.set_configuration_location(app, conf_file)
@@ -44,6 +36,7 @@ def equal_weight_app():
     with app.app_context():
         db.session.remove()
         db.drop_all()
+        os.unlink(os.path.join(os.path.join(app.instance_path), 'test_admin_database.db'))
         os.unlink(os.path.join(os.path.join(app.instance_path), 'test_database.db'))
 
 
@@ -63,6 +56,7 @@ def custom_weight_app():
     with app.app_context():
         db.session.remove()
         db.drop_all()
+        os.unlink(os.path.join(os.path.join(app.instance_path), 'test_admin_database.db'))
         os.unlink(os.path.join(os.path.join(app.instance_path), 'test_database.db'))
 
 

--- a/tests_python/integration_tests/test_api.py
+++ b/tests_python/integration_tests/test_api.py
@@ -14,11 +14,10 @@ from comparison_interface.db.setup import Setup as DBSetup
 # custom fixtures for these tests
 def execute_setup_with_api(conf_file):
     app = create_app(
-        {
-            "TESTING": True,
+        testing=True,
+        test_config={
             "API_ACCESS": True,
             "API_KEY_FILE": ".tstkyapi",
-            "SQLALCHEMY_DATABASE_URI": 'sqlite:///test_database.db',
         }
     )
     # 1. Validate the website configuration
@@ -42,6 +41,7 @@ def equal_weight_app_api():
     with app.app_context():
         db.session.remove()
         db.drop_all()
+        os.unlink(os.path.join(os.path.join(app.instance_path), 'test_admin_database.db'))
         os.unlink(os.path.join(os.path.join(app.instance_path), 'test_database.db'))
 
 

--- a/tests_python/unit_tests/test_validation.py
+++ b/tests_python/unit_tests/test_validation.py
@@ -42,7 +42,7 @@ def test_setup_works_for_directory_with_csv():
     WHEN the location is set using an valid directory path
     THEN the app is created
     """
-    app = create_app({"TESTING": True, "SQLALCHEMY_DATABASE_URI": 'sqlite:///test_database.db'})
+    app = create_app(testing=True)
     # 1. Validate the website configuration
     app.logger.info("Setting website configuration")
     WS.set_configuration_location(app, "../tests_python/test_configurations/csv_example_1")
@@ -61,7 +61,7 @@ def test_setup_fails_for_directory_with_wrong_files():
     WHEN the location is set using an invalid directory path
     THEN the system exits
     """
-    app = create_app({"TESTING": True, "SQLALCHEMY_DATABASE_URI": 'sqlite:///test_database.db'})
+    app = create_app(testing=True)
     # 1. Validate the website configuration
     app.logger.info("Setting website configuration")
     WS.set_configuration_location(app, "../tests_python/test_configurations")


### PR DESCRIPTION
I think this is a better setup for testing where we can have a base level of settings for testing that individual tests can override to check different setting options like turning on the api or the admin interface.