### PR TITLE
Add ProxyFix middleware to emulate FORCE_SCRIPT_NAME

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
-from comparison_interface import create_app
 from werkzeug.middleware.proxy_fix import ProxyFix
+
+from comparison_interface import create_app
 
 app = create_app()
 

--- a/app.py
+++ b/app.py
@@ -1,3 +1,7 @@
 from comparison_interface import create_app
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 app = create_app()
+
+# Tell Flask to use X-Script-Name header as SCRIPT_NAME
+app.wsgi_app = ProxyFix(app.wsgi_app, x_prefix=1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
     "numpy",
     "cachetools",
     "dotenv",
-    "werkzeug",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "numpy",
     "cachetools",
     "dotenv",
+    "werkzeug",
 ]
 
 


### PR DESCRIPTION
Use werkzeug.middleware.proxy_fix.ProxyFix with x_prefix=1 so the Flask app respects X-Script-Name set by Nginx/uWSGI.

This ensures URL generation (url_for) and request paths work correctly when the app is served under a subpath (e.g., /study1), similar to Django's FORCE_SCRIPT_NAME.