### PR TITLE
allow app to run on subdomains if nginx/uwsgi is setup for that

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,3 +1,17 @@
+import os
+
+from dotenv import load_dotenv
+from werkzeug.middleware.dispatcher import DispatcherMiddleware
+
 from comparison_interface import create_app
 
-app = create_app()
+load_dotenv()
+
+subdomain = os.getenv("SUBDOMAIN", "")
+
+if subdomain == "":
+    app = create_app()
+else:
+    app = DispatcherMiddleware(None, {
+        subdomain: create_app()
+    })

--- a/app.py
+++ b/app.py
@@ -12,6 +12,4 @@ subdomain = os.getenv("SUBDOMAIN", "")
 if subdomain == "":
     app = create_app()
 else:
-    app = DispatcherMiddleware(None, {
-        subdomain: create_app()
-    })
+    app = DispatcherMiddleware(None, {subdomain: create_app()})


### PR DESCRIPTION
This allows us to run on different subdomains without breaking the dev server.

The actual string for the subdomain comes from the .env file meaning it can persist between code updates and doesn't need editing in the repo code at all.

I wasn't planning on documenting this since it is very specific to our server setup but if you think I should then let me know and I will add it.