### PR TITLE
More subdomain fixes

### DIFF
--- a/comparison_interface/__init__.py
+++ b/comparison_interface/__init__.py
@@ -188,12 +188,16 @@ def _validate_app_integrity():
 
 def _page_not_found(e):
     """Return 404 page."""
+    subdomain = current_app.config["SUBDOMAIN"]
+    if subdomain == "":
+        subdomain = "/"
     # this is a backup system for when system is not configured yet (or sometimes the admin isn't set up)
     if WS.CONFIGURATION_LOCATION not in current_app.config:
         data = {
             'error_404_title': '404',
             'error_404_message': 'Page not found',
             'error_404_home_link': 'Go to home page',
+            'error_404_home_location': subdomain,
         }
         return render_template('404.html', **data)
     else:
@@ -201,6 +205,7 @@ def _page_not_found(e):
             'error_404_title': WS.get_text(WS.ERROR_404_TITLE, current_app),
             'error_404_message': WS.get_text(WS.ERROR_404_MESSAGE, current_app),
             'error_404_home_link': WS.get_text(WS.ERROR_404_HOME_LINK, current_app),
+            'error_404_home_location': subdomain,
         }
     return render_template('404.html', **{**data, **Request(current_app, session).get_layout_text()}), 404
 

--- a/comparison_interface/admin/routes.py
+++ b/comparison_interface/admin/routes.py
@@ -97,6 +97,10 @@ def dashboard():
 @blueprint.route("/logged-out", methods=["GET"])
 def logged_out():
     """Display a post log out page."""
+    current_app.logger.critical("********")
+    current_app.logger.critical(WS.CONFIGURATION_LOCATION)
+    current_app.logger.critical(current_app.config[WS.CONFIGURATION_LOCATION])
+    current_app.logger.critical("********")
     subdomain = current_app.config["SUBDOMAIN"]
     if subdomain == "":
         subdomain = "/"

--- a/comparison_interface/admin/routes.py
+++ b/comparison_interface/admin/routes.py
@@ -97,6 +97,9 @@ def dashboard():
 @blueprint.route("/logged-out", methods=["GET"])
 def logged_out():
     """Display a post log out page."""
+    subdomain = current_app.config["SUBDOMAIN"]
+    if subdomain == "":
+        subdomain = "/"
     if WS.CONFIGURATION_LOCATION in current_app.config and current_app.config[WS.CONFIGURATION_LOCATION] is not None:
         website_title = WS.get_text(WS.WEBSITE_TITLE, current_app)
         has_current_study = True
@@ -107,6 +110,7 @@ def logged_out():
         "logged_out": True,
         "has_current_study": has_current_study,
         "website_title": website_title,
+        "home_location": subdomain,
     }
     return render_template("logged-out.html", **data)
 

--- a/comparison_interface/admin/templates/logged-out.html
+++ b/comparison_interface/admin/templates/logged-out.html
@@ -5,7 +5,7 @@
         <h1 class="fs-3">Admin Logged Out</h1>
         <p>You have been logged out of the admin interface.</p>
         {% if has_current_study %}
-            <a href="/">Go to participant view of current study</a>
+            <a href="{{ home_location }}">Go to participant view of current study</a>
         {% else %}
             <p>There is no current study so you will need to log in again to create a study. You can log in using the link in the header.</p>
         {% endif %}

--- a/comparison_interface/configuration/example.flask.py
+++ b/comparison_interface/configuration/example.flask.py
@@ -29,6 +29,7 @@ class Settings(object):
     SESSION_COOKIE_SECURE = True
     SESSION_COOKIE_HTTPONLY = True
     SESSION_COOKIE_SAMESITE = 'strict'
+    SUBDOMAIN = os.getenv("SUBDOMAIN", "")
     MAX_CONTENT_LENGTH = 4 * 1024 * 1024
     LANGUAGE = os.getenv('LANGUAGE', 'en')
     API_ACCESS = get_bool_value('API_ACCESS', False)

--- a/comparison_interface/configuration/flask_testing.py
+++ b/comparison_interface/configuration/flask_testing.py
@@ -12,6 +12,7 @@ class TestSettings(object):
     SESSION_COOKIE_SECURE = False
     SESSION_COOKIE_HTTPONLY = False
     SESSION_COOKIE_SAMESITE = 'strict'
+    SUBDOMAIN = ""
     MAX_CONTENT_LENGTH = 4 * 1024 * 1024
     LANGUAGE = 'en'
     API_ACCESS = False

--- a/comparison_interface/templates/404.html
+++ b/comparison_interface/templates/404.html
@@ -8,7 +8,7 @@
         <div class="text-center">
             <h1>404</h1>
             <p>{{ error_404_message }}</p>
-            <p><a href="/">{{ error_404_home_link }}</a></p>
+            <p><a href="{{ error_404_home_location }}">{{ error_404_home_link }}</a></p>
         </div>
     </div>
 {% endblock %}

--- a/tests/test_configurations/flask_testing_config.json
+++ b/tests/test_configurations/flask_testing_config.json
@@ -10,6 +10,7 @@
     "SESSION_COOKIE_SECURE": false,
     "SESSION_COOKIE_HTTPONLY": false,
     "SESSION_COOKIE_SAMESITE": "strict",
+    "SUBDOMAIN": "",
     "MAX_CONTENT_LENGTH": 4000000,
     "LANGUAGE": "en",
     "API_ACCESS": false,

--- a/tests/test_configurations/testing-admin.flask.py
+++ b/tests/test_configurations/testing-admin.flask.py
@@ -16,6 +16,7 @@ class Settings(object):
     SESSION_COOKIE_SECURE = False
     SESSION_COOKIE_HTTPONLY = False
     SESSION_COOKIE_SAMESITE = 'strict'
+    SUBDOMAIN = ''
     MAX_CONTENT_LENGTH = 4 * 1024 * 1024
     LANGUAGE = 'en'
     API_ACCESS = False


### PR DESCRIPTION
Fix a few new subdomain issues with links. 

This required adding subdomain to the flask settings so we could easily access it from a range of places. 

Some of them still seem to be glitching sometimes so I have added some logging print outs for the time being to monitor that more easily. We can remove them once I think it is working correctly. Without the logs working out what is going on when it is on the server running on the split domain is impossible (and I haven't been able to recreate that locally).

This also fixes the tests which also need the subdomain adding into some test specific configs.
