### PR TITLE
update minimum python and marshmallow version

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -9,10 +9,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
         - uses: actions/checkout@v4
-        - name: Install Python 3.9
+        - name: Install Python 3.12
           uses: actions/setup-python@v5
           with: 
-            python-version: "3.9"
+            python-version: "3.12"
         - name: Install node
           uses: actions/setup-node@v4
           with:
@@ -43,10 +43,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
         - uses: actions/checkout@v4
-        - name: Install Python 3.9
+        - name: Install Python 3.12
           uses: actions/setup-python@v5
           with: 
-            python-version: "3.9"
+            python-version: "3.12"
         - name: Install node
           uses: actions/setup-node@v4
           with:
@@ -77,10 +77,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
         - uses: actions/checkout@v4
-        - name: Install Python 3.9
+        - name: Install Python 3.12
           uses: actions/setup-python@v5
           with: 
-            python-version: "3.9"
+            python-version: "3.12"
         - name: Install node
           uses: actions/setup-node@v4
           with:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -9,10 +9,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
         - uses: actions/checkout@v4
-        - name: Install Python 3.9
+        - name: Install Python 3.12
           uses: actions/setup-python@v5
           with: 
-            python-version: "3.9"
+            python-version: "3.12"
         - name: Install dependencies
           run: |
             python -m venv venv
@@ -30,10 +30,10 @@ jobs:
       runs-on: ubuntu-latest
       steps:
       - uses: actions/checkout@v4
-      - name: Install Python 3.9
+      - name: Install Python 3.12
         uses: actions/setup-python@v5
         with: 
-          python-version: "3.9"
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m venv venv
@@ -75,4 +75,3 @@ jobs:
           npm i stylelint-config-standard
           npm i @stylistic/stylelint-plugin
           node_modules/stylelint/bin/stylelint.mjs ./comparison_interface/static/css
-      

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -9,10 +9,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
         - uses: actions/checkout@v4
-        - name: Install Python 3.9
+        - name: Install Python 3.12
           uses: actions/setup-python@v5
           with: 
-            python-version: "3.9"
+            python-version: "3.12"
         - name: Install dependencies
           run: |
             python -m venv venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ dependencies = [
 
 [project.optional-dependencies]
 admin = [
-    "flask-security[fsqla,common,mfa]<5.7",
+    "Flask-Mailman",
+    "flask-security[fsqla,common,mfa]",
     "markdown",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 
 [project.optional-dependencies]
 admin = [
-    "flask-security[fsqla,common,mfa]",
+    "flask-security[fsqla,common,mfa]<5.7",
     "markdown",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,13 +3,13 @@ name = "Comparison-Interface"
 version = "2.1.0"
 description = "A web interface to facilitate the collection of comparative judgement data."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 dependencies = [
     "Flask>=3.1,<3.2",
     "SQLAlchemy>=2.0,<2.1",
     "Flask-SQLAlchemy>=3.1,<3.2",
-    "marshmallow>=4.0,<4.1",
+    "marshmallow>=4.0,<5.0",
     "whitenoise",
     "pillow",
     "numpy",

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -1,2 +1,0 @@
-wheel
-uwsgi


### PR DESCRIPTION
This updates the version of marshmallow we use due to a dependabot alert with the current version.

Also updates mimumum python version in toml file and updates the CI worfklow python to 3.12 to match our live environment.

Adds flask_mailman as explicit dependency to overule the change to the default in flask-security.

And deleted an old requirements-server.txt file that was hanging around from before we switched to a toml file.
