### PR TITLE
Stop restricting flask security

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ dependencies = [
 
 [project.optional-dependencies]
 admin = [
-    "flask-security[fsqla,common,mfa]<5.7",
+    "Flask-Mailman",
+    "flask-security[fsqla,common,mfa]",
     "markdown",
 ]
 


### PR DESCRIPTION
This simple change flips the default mail back.