### PR TITLE
correct paths

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -51,7 +51,7 @@ To setup the system for the main test file (in all code snippets below the setup
 `reset` command if you already have a database in use):
 
 ```bash
-flask --debug setup ../test_configurations/config-equal-item-weights-2.json
+flask --debug setup ../tests/test_configurations/config-equal-item-weights-2.json
 flask --debug run ---port=5001
 ```
 
@@ -64,7 +64,7 @@ npx jest -- tests_accessibility/accessibility.test.js
 To run the additional study configuration test file:
 
 ```bash
-flask --debug setup ../test_configurations/config-equal-item-weights.json
+flask --debug setup ../tests/test_configurations/config-equal-item-weights.json
 flask --debug run ---port=5001
 ```
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -5,7 +5,8 @@ title: Running the Tests
 
 Three different kinds of tests are provided, Python tests, JavaScript tests and accessibility tests.
 
-All of the dependencies needed to run the full suite of tests are included in the dev container.
+All of the dependencies needed to run the full suite of tests are included in the dev container. However, the browser automation
+tests using playwright which are used to test the admin interface will not run in the dev container.
 
 If you are not using the dev container, to run the Python tests you will need to install the dependencies in the `test`
 section of the pyproject.toml.
@@ -25,6 +26,13 @@ The Python tests are written in pytest and can be found in the `tests/tests_pyth
 
 ```bash
 pytest
+```
+
+If you are using the dev container then the admin tests will fail if you use the command above because the dev container cannot
+run tests that use playwright. To run all of the other tests and not the admin tests you can run:
+
+```bash
+pytest tests/python_tests
 ```
 
 **Note:** The configuration files used for testing are not the same as the example configuration files provided with the


### PR DESCRIPTION
This just corrects two paths in the docs and add a note that the admin tests don't work in the dev container. I have tried to debug this but have not found a solution. They work in the CI and in a local install so I think it is okay that they don't work in the dev container - it is something to do with playwright and the browser automation.