### PR TITLE
change env variable name because of default setting

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -5,7 +5,7 @@ SECURITY_PASSWORD_SALT = "Add your salt key"
 MAIL_DEFAULT_SENDER = "no-reply@flask_app"
 
 # optional general variables
-# LANGUAGE = 'en'
+# INTERFACE_LANGUAGE = 'en'
 
 # optional variables relating to the API
 # API_ACCESS = True

--- a/comparison_interface/configuration/example.flask.py
+++ b/comparison_interface/configuration/example.flask.py
@@ -31,7 +31,7 @@ class Settings(object):
     SESSION_COOKIE_SAMESITE = 'strict'
     SUBDOMAIN = os.getenv("SUBDOMAIN", "")
     MAX_CONTENT_LENGTH = 4 * 1024 * 1024
-    LANGUAGE = os.getenv('LANGUAGE', 'en')
+    LANGUAGE = os.getenv('INTERFACE_LANGUAGE', 'en')
     API_ACCESS = get_bool_value('API_ACCESS', False)
     API_KEY_FILE = os.getenv('API_KEY_FILE', '.apikey')
     ADMIN_ACCESS = get_bool_value('ADMIN_ACCESS', False)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,11 +45,11 @@ languages. All of the keys in the JSON should be present for any additional lang
 the language used to name the file for example `en.json` or `de.json`. Using the correct ISO code is important as it
 will be used to set the language of the webpage enabling screen readers to select the correct voice settings for the language.
 
-To tell the system which file to use, change the setting in the `flask.py` file in the `configuration` directory. The
+To tell the system which file to use, change the environment variable `INTERFACE_LANGUAGE` in the .env file. The
 configuration for English is as follows:
 
-```python
-    LANGUAGE = 'en'
+```bash
+    INTERFACE_LANGUAGE = 'en'
 ```
 
 This will look for the display strings in `languages/en.json`.


### PR DESCRIPTION
LANGUAGE can't be used as an environment variable because the system setting always overules it. This change allows a language to be set for the interface which is different from the locale setting on the machine.